### PR TITLE
Update instant.hjson

### DIFF
--- a/content/blocks/turrets/instant.hjson
+++ b/content/blocks/turrets/instant.hjson
@@ -19,18 +19,21 @@ ammoTypes: {
     damage: 18
     ammoMultiplier: 6
     drawSize: 4
+    lifetime: 20
   }
   lead: {
     speed: 16
     damage: 22
     ammoMultiplier: 3
     drawSize: 4
+    lifetime: 20
   }
   coal: {
     speed: 16
     damage: 19
     ammoMultiplier: 3
     drawSize: 4
+    lifetime: 20
     incendAmount: 0.5
     incendSpread: 0.1
     incendChance: 0.5
@@ -40,6 +43,7 @@ ammoTypes: {
     damage: 22
     ammoMultiplier: 3
     drawSize: 4
+    lifetime: 20
     homingPower: 12
   }
   titanium: {
@@ -47,6 +51,7 @@ ammoTypes: {
     damage: 65
     ammoMultiplier: 3
     drawSize: 4
+    lifetime: 20
     reloadMultiplier: 0.6
   }
   polonium: {
@@ -54,6 +59,7 @@ ammoTypes: {
     damage: 100
     ammoMultiplier: 1
     drawSize: 4
+    lifetime: 20
     reloadMultiplier: 0.4
   }
 }

--- a/content/blocks/turrets/instant.hjson
+++ b/content/blocks/turrets/instant.hjson
@@ -19,21 +19,21 @@ ammoTypes: {
     damage: 18
     ammoMultiplier: 6
     drawSize: 4
-    lifetime: 20
+    lifetime: 12
   }
   lead: {
     speed: 16
     damage: 22
     ammoMultiplier: 3
     drawSize: 4
-    lifetime: 20
+    lifetime: 12
   }
   coal: {
     speed: 16
     damage: 19
     ammoMultiplier: 3
     drawSize: 4
-    lifetime: 20
+    lifetime: 12
     incendAmount: 0.5
     incendSpread: 0.1
     incendChance: 0.5
@@ -43,7 +43,7 @@ ammoTypes: {
     damage: 22
     ammoMultiplier: 3
     drawSize: 4
-    lifetime: 20
+    lifetime: 12
     homingPower: 12
   }
   titanium: {
@@ -51,7 +51,7 @@ ammoTypes: {
     damage: 65
     ammoMultiplier: 3
     drawSize: 4
-    lifetime: 20
+    lifetime: 12
     reloadMultiplier: 0.6
   }
   polonium: {
@@ -59,7 +59,7 @@ ammoTypes: {
     damage: 100
     ammoMultiplier: 1
     drawSize: 4
-    lifetime: 20
+    lifetime: 12
     reloadMultiplier: 0.4
   }
 }


### PR DESCRIPTION
Add a lifetime value of 20 to ammo modifiers to prevent the projectiles from travelling significantly farther than the range of turret.